### PR TITLE
add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "wordpress6dev",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/php:1": {
+      "version": "7.4"
+    },
+    "ghcr.io/devcontainers/features/node:1.1.1": {
+      "version": "19.0"
+    }
+  },
+  "extensions": [
+    "GitHub.github-vscode-theme",
+    "bmewburn.vscode-intelephense-client",
+    "shevaua.phpcs",
+    "persoderlind.vscode-phpcbf",
+    "yogensia.searchwpdocs",
+    "johnbillion.vscode-wordpress-hooks",
+    "wordpresstoolbox.wordpress-toolbox",
+    "dbaeumer.vscode-eslint",
+    "ms-vscode-remote.remote-containers"
+  ],
+  "onCreateCommand": "echo PS1='\"$ \"' >> ~/.bashrc",
+  "postCreateCommand": "composer install && npm install",
+  "postStartCommand": "make up"
+}
+// DevContainer Reference: https://code.visualstudio.com/docs/remote/devcontainerjson-reference


### PR DESCRIPTION
The goal of this PR is, to config a codespace with version constraints on both php and node.
WordPress recommends to run on php 7.4, not latest and node-sass is very picky about den Node-version, so I need to constain it as well.

The devcontainer.json produces an error. Could you please help me. I need the following:
- php 7.4
- node 19

In addition to that, phpcs ( a tool installed by composer) outputs an error about a misconfiguration of xdebug. This leads to an error in the codesniffing extension of VS Code, because the output is no longer well-formed json.

Both topics (version constraint and xdebug-error) are commented in the PR. 

Would you like to help me solves this issue?

Thanks.

**SEE BRANCH named selfconfig for my nearly working solution**